### PR TITLE
Fix Docker Compose startup error - "Unable to connect to db:7687

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       db:
         condition: service_healthy
   db:
-    image: neo4j:latest
+    image: neo4j:5.23
     environment:
       NEO4J_AUTH: neo4j/12345678
       NEO4JLABS_PLUGINS: "[\"apoc\"]"
@@ -22,7 +22,7 @@ services:
       - "7474:7474"
       - "7687:7687"
     healthcheck:
-      test: wget --quiet --spider http://db:7474/db/data && echo 'Health check passed' || echo 'Health check failed'
+      test: wget http://db:7474 || exit 1
       interval: 10s
       timeout: 3s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       NEO4J_USERNAME: neo4j
       NEO4J_PASSWORD: 12345678
       NEO4J_DATABASE: neo4j
+    depends_on:
+      db:
+        condition: service_healthy
   db:
     image: neo4j:latest
     environment:
@@ -19,9 +22,9 @@ services:
       - "7474:7474"
       - "7687:7687"
     healthcheck:
-      test: ["CMD-SHELL", "curl", "--fail", "http://db:7474/db/data"]
-      interval: 30s
-      timeout: 10s
+      test: wget --quiet --spider http://db:7474/db/data && echo 'Health check passed' || echo 'Health check failed'
+      interval: 10s
+      timeout: 3s
       retries: 5
 
 volumes:


### PR DESCRIPTION
[//]: # (Copyright 2024 Paion Data)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

The `web` container did not start after the `db` container started successfully.
I've changed docker-compose to this: 
```
services:
  web:
    build: .
    ports:
      - "8080:8080"
    environment:
      NEO4J_URI: bolt://db:7687
      NEO4J_USERNAME: neo4j
      NEO4J_PASSWORD: 12345678
      NEO4J_DATABASE: neo4j
    depends_on:
      db:
        condition: service_healthy
  db:
    image: neo4j:latest
    environment:
      NEO4J_AUTH: neo4j/12345678
      NEO4JLABS_PLUGINS: "[\"apoc\"]"
    volumes:
      - neo4j-data:/data
    ports:
      - "7474:7474"
      - "7687:7687"
    healthcheck:
      test: ["CMD-SHELL", "curl", "--fail", "http://db:7474/db/data"]
      interval: 30s
      timeout: 10s
      retries: 5

volumes:
  neo4j-data:
```

It still doesn't work. 
By entering `docker inspect --format='{{json.State. Health}}' db`, I find that `curl` is not installed inside the neo4j container, causing the health check to fail. I solved this problem by switching to `wget`.

Changelog
---------

### Added
```
    healthcheck:
      test: wget --quiet --spider http://db:7474/db/data && echo 'Health check passed' || echo 'Health check failed'
      interval: 10s
      timeout: 3s
      retries: 5
```
