### PR TITLE
Publish documentation to dedicated domain 'aristotle-ws.com'

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -49,6 +49,10 @@ jobs:
         working-directory: docs
         run: yarn build
 
+      - name: Load CNAME file
+        if: github.ref == 'refs/heads/master'
+        run: cp docs/CNAME docs/build
+
       - name: Deploy Documentation to GitHub Pages
         if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The use and distribution terms for [Aristotle] are covered by the [Apache Licens
 [Docker Compose badge]: https://img.shields.io/badge/Docker%20Compose-2596EC?style=for-the-badge&logo=docker&logoColor=white
 
 [Aristotle]: https://github.com/paion-data/aristotle
-[Documentation]: https://paion-data.github.io/aristotle/
+[Documentation]: https://aristotle-ws.com
 
 [Neo4j]: https://neo4j.com
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+aristotle-ws.com

--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -91,4 +91,4 @@ The web service will run on port **8080**.
 
 You can access the OpenAPI documentation at **http://localhost:8080/doc.html**. This documentation is built using **Swagger 2** and enhanced with **Knife4J**.
 
-[Aristotle]: https://paion-data.github.io/aristotle/
+[Aristotle]: https://aristotle-ws.com

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -20,7 +20,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'Aristotle',
-  tagline: 'A webservice for Graph Database',
+  tagline: 'Webservice with first-class support for Graph Database',
   favicon: 'img/favicon.ico',
 
   url: 'https://aristotle-ws.com',

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -20,11 +20,11 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'Aristotle',
-  tagline: 'Build your knowledge graph',
+  tagline: 'A webservice for Graph Database',
   favicon: 'img/favicon.ico',
 
-  url: 'https://aristotle.io',
-  baseUrl: '/aristotle/',
+  url: 'https://aristotle-ws.com',
+  baseUrl: '/',
 
   organizationName: 'paion-data',
   projectName: 'aristotle',


### PR DESCRIPTION
[//]: # (Copyright 2024 Paion Data)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Added

### Changed

- Bound documentation to our own domain [aristotle-ws.com](https://aristotle-ws.com/) we just purchased (all `aristotle.x` domains are unavilable. `aristotle-ws.com` is a great alternative for webservice project)

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation
