### PR TITLE
Add javadoc plugin and add deployment steps in CI-CD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
+      - name: Set up JDK
+        uses: paion-data/immutable-infrastructure-as-a-service/.github/actions/jdk-setup@master
+
       - name: Install Dependencies
         working-directory: docs
         run: yarn
@@ -49,11 +52,18 @@ jobs:
         working-directory: docs
         run: yarn build
 
+      - name: Generate Javadoc
+        run: mvn -B clean javadoc:javadoc
+
+      - name: Move Javadoc into documentation directory
+        if: github.ref == 'refs/heads/master'
+        run: mv target/site/apidocs/ docs/build/apidocs/
+
       - name: Load CNAME file
         if: github.ref == 'refs/heads/master'
         run: cp docs/CNAME docs/build
 
-      - name: Deploy Documentation to GitHub Pages
+      - name: Deploy Documentation (including Javadoc) to GitHub Pages
         if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -69,6 +69,11 @@ const config: Config = {
                 label: 'Documentation',
             },
             {
+                href: "https://aristotle-ws.com/apidocs",
+                label: "API",
+                position: "left",
+            },
+            {
                 href: 'https://github.com/paion-data/aristotle',
                 label: ' ',
                 position: 'right',

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <hutool.version>5.8.29</hutool.version>
         <spring-boot.version>3.3.2</spring-boot.version>
 
+        <version.maven.javadoc.plugin>3.5.0</version.maven.javadoc.plugin>
         <version.knife4j>3.0.3</version.knife4j>
         <version.springfox>3.0.0</version.springfox>
         <version.maven.checkstyle.plugin>3.1.2</version.maven.checkstyle.plugin>
@@ -230,6 +231,23 @@
                         <phase>initialize</phase>
                         <goals>
                             <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${version.maven.javadoc.plugin}</version>
+                <configuration>
+                    <doclint>none</doclint>  <!-- Turnoff all checks -->
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
[//]: # (Copyright 2024 Paion Data)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Added
Add javadoc plugin and add deployment steps in CI-CD