### PR TITLE
Remove the bindNodes interface and delegate the functionality of creating relationships to createAndBindNode interface

### DIFF
--- a/src/main/java/com/paiondata/aristotle/controller/NodeController.java
+++ b/src/main/java/com/paiondata/aristotle/controller/NodeController.java
@@ -17,7 +17,6 @@ package com.paiondata.aristotle.controller;
 
 import com.paiondata.aristotle.common.base.Message;
 import com.paiondata.aristotle.common.base.Result;
-import com.paiondata.aristotle.model.dto.NodeRelationDTO;
 import com.paiondata.aristotle.model.vo.GraphVO;
 import com.paiondata.aristotle.model.vo.NodeVO;
 import com.paiondata.aristotle.model.dto.NodeCreateDTO;
@@ -47,7 +46,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import java.util.List;
@@ -136,10 +134,12 @@ public class NodeController {
      *
      * @return a {@link Result} object containing a success message and a list of created nodes as {@link NodeVO}
      *
-     * @notes The nodes could be created without binding any relations
+     * @notes The nodes could be created without binding any relations,
+     * or create relationships only on existing nodes without creating new nodes
      */
     @ApiOperation(value = "Creates and binds nodes",
-            notes = "The nodes could be created without binding any relations")
+            notes = "The nodes could be created without binding any relations, "
+                    + "or create relationships only on existing nodes without creating new nodes")
     @PostMapping
     public Result<List<NodeVO>> createAndBindNode(@RequestBody @Valid final NodeCreateDTO graphNodeCreateDTO) {
         return Result.ok(Message.CREATE_SUCCESS, nodeService.createAndBindGraphAndNode(graphNodeCreateDTO, null));
@@ -165,26 +165,6 @@ public class NodeController {
     public Result<GraphVO> createGraphAndBindGraphAndNode(
             @RequestBody @Valid final GraphAndNodeCreateDTO graphNodeCreateDTO) {
         return Result.ok(nodeService.createGraphAndBindGraphAndNode(graphNodeCreateDTO, null));
-    }
-
-    /**
-     * Binds multiple nodes.
-     *
-     * <p>
-     * This method handles a POST request to bind multiple nodes.
-     * It validates the input DTOs and calls the node service to perform the binding.
-     * The result is wrapped in a {@link Result} object with a success message.
-     *
-     * @param dtos a list of {@link NodeRelationDTO} objects containing the binding information for the nodes
-     *
-     * @return a {@link Result} object containing a success message
-     */
-    @ApiOperation(value = "Binds multiple nodes")
-    @PostMapping("/bind")
-    public Result<String> bindNodes(@RequestBody @NotEmpty(message = Message.BIND_DTOS_MUST_NOT_EMPTY)
-                                        @Valid final List<NodeRelationDTO> dtos) {
-        nodeService.bindNodes(dtos, null);
-        return Result.ok(Message.BOUND_SUCCESS);
     }
 
     /**

--- a/src/main/java/com/paiondata/aristotle/model/dto/GraphAndNodeCreateDTO.java
+++ b/src/main/java/com/paiondata/aristotle/model/dto/GraphAndNodeCreateDTO.java
@@ -66,7 +66,7 @@ public class GraphAndNodeCreateDTO extends BaseEntity {
      */
     @ApiModelProperty(value = "The list of nodes to be created within the graph. This field is optional.")
     @Valid
-    private List<NodeDTO> graphNodeDTO;
+    private List<NodeDTO> nodeDTO;
 
     /**
      * The list of relations between nodes within the graph.
@@ -79,5 +79,5 @@ public class GraphAndNodeCreateDTO extends BaseEntity {
      */
     @ApiModelProperty(value = "The list of relations between nodes within the graph. This field is optional.")
     @Valid
-    private List<NodeRelationDTO> graphNodeRelationDTO;
+    private List<NodeRelationDTO> nodeRelationDTO;
 }

--- a/src/main/java/com/paiondata/aristotle/model/dto/NodeCreateDTO.java
+++ b/src/main/java/com/paiondata/aristotle/model/dto/NodeCreateDTO.java
@@ -27,7 +27,6 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.List;
 
 /**
@@ -66,10 +65,9 @@ public class NodeCreateDTO extends BaseEntity {
      * @see NodeDTO
      */
     @ApiModelProperty(value = "The list of nodes to be created within the graph. "
-            + "This field is required and must not be null.", required = true)
-    @NotNull
+            + "One can create relationships without passing this field.")
     @Valid
-    private List<NodeDTO> graphNodeDTO;
+    private List<NodeDTO> nodeDTO;
 
     /**
      * The list of relations between nodes within the graph.
@@ -86,5 +84,5 @@ public class NodeCreateDTO extends BaseEntity {
     @ApiModelProperty(value = "The list of relations between nodes within the graph. "
             + "One can create nodes without passing this field if no relationships are needed.")
     @Valid
-    private List<NodeRelationDTO> graphNodeRelationDTO;
+    private List<NodeRelationDTO> nodeRelationDTO;
 }

--- a/src/main/java/com/paiondata/aristotle/service/NodeService.java
+++ b/src/main/java/com/paiondata/aristotle/service/NodeService.java
@@ -15,7 +15,6 @@
  */
 package com.paiondata.aristotle.service;
 
-import com.paiondata.aristotle.model.dto.NodeRelationDTO;
 import com.paiondata.aristotle.model.vo.GraphVO;
 import com.paiondata.aristotle.model.dto.NodeDeleteDTO;
 import com.paiondata.aristotle.model.vo.NodeVO;
@@ -63,14 +62,6 @@ public interface NodeService {
      * @return the created graph node
      */
     GraphVO createGraphAndBindGraphAndNode(GraphAndNodeCreateDTO graphNodeCreateDTO, Transaction tx);
-
-    /**
-     * Binds nodes based on the provided DTOs.
-     *
-     * @param dtos the list of DTOs for binding nodes
-     * @param tx   the Neo4j transaction
-     */
-    void bindNodes(List<NodeRelationDTO> dtos, Transaction tx);
 
     /**
      * Deletes graph nodes by their UUIDs.

--- a/src/test/java/com/paiondata/aristotle/controller/NodeControllerIT.java
+++ b/src/test/java/com/paiondata/aristotle/controller/NodeControllerIT.java
@@ -171,45 +171,11 @@ public class NodeControllerIT extends AbstractIT {
     }
 
     /**
-     * Parameterized test to verify if the JSON API correctly handles invalid node updating requests by returning a
-     * 400 Bad Request status code and appropriate error messages.
-     *
-     * @param fromId The from ID to be used in the request body.
-     * @param relationName The relation name to be used in the request body.
-     * @param toId The to ID to be used in the request body.
-     * @param expectedMsg The expected error message.
-     */
-    @ParameterizedTest
-    @CsvSource({
-            "'', relation, id2, bindNodes.dtos[0].fromId: fromId must not be blank!",
-            "id1, '', id2, bindNodes.dtos[0].relationName: relation must not be blank!",
-            "id1, relation, '', bindNodes.dtos[0].toId: toId must not be blank!"})
-    @Order(3)
-    void jsonApiHandlesInvalidNodeUpdatingRequests(final String fromId, final String relationName, final String toId,
-                                                   final String expectedMsg) {
-        final Response response = RestAssured
-                .given()
-                .contentType(ContentType.JSON)
-                .accept(ContentType.JSON)
-                .body(String.format(payload("relate-node-to-valid.json"), fromId, relationName, toId))
-                .when()
-                .post(NODE_ENDPOINT + "/bind")
-                .then()
-                .extract()
-                .response();
-
-        response.then()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
-
-        assertEquals(expectedMsg, response.jsonPath().get(TestConstants.MSG));
-    }
-
-    /**
      * Tests if the JSON API correctly handles invalid node updating requests by returning a 400 Bad Request status code
      * and appropriate error messages.
      */
     @Test
-    @Order(4)
+    @Order(3)
     void jsonApiHandlesInvalidNodeUpdatingRequests() {
         final Response response = RestAssured
                 .given()
@@ -234,7 +200,7 @@ public class NodeControllerIT extends AbstractIT {
      * response data is empty.
      */
     @Test
-    @Order(5)
+    @Order(4)
     void databaseIsEmpty() {
         final Response response = RestAssured
                 .given()
@@ -252,7 +218,7 @@ public class NodeControllerIT extends AbstractIT {
      * verifying the response.
      */
     @Test
-    @Order(6)
+    @Order(5)
     void anUserEntityIsPostedViaJsonApi() {
         final Response response = RestAssured
                 .given()
@@ -277,7 +243,7 @@ public class NodeControllerIT extends AbstractIT {
      * node/graph endpoint and verifying the response.
      */
     @Test
-    @Order(7)
+    @Order(6)
     void anGraphEntityIsPostedViaJsonApiWithoutAnyNode() {
         final Response response = RestAssured
                 .given()
@@ -304,7 +270,7 @@ public class NodeControllerIT extends AbstractIT {
      * verifying the response.
      */
     @Test
-    @Order(8)
+    @Order(7)
     void nodeEntityIsPostedViaJsonApi() {
         final Response response = RestAssured
                 .given()
@@ -335,7 +301,7 @@ public class NodeControllerIT extends AbstractIT {
      * and verifying the response.
      */
     @Test
-    @Order(9)
+    @Order(8)
     void weCanGetThatNodeEntityNext() {
         final Response response = RestAssured
                 .given()
@@ -364,7 +330,7 @@ public class NodeControllerIT extends AbstractIT {
      * and verifying the response.
      */
     @Test
-    @Order(10)
+    @Order(9)
     void weCanUpdateThatNodeEntity() {
         RestAssured
                 .given()
@@ -382,7 +348,7 @@ public class NodeControllerIT extends AbstractIT {
      * and verifying the response.
      */
     @Test
-    @Order(11)
+    @Order(10)
     void weCanGetThatNodeEntityWithUpdatedAttribute() {
         final Response response = RestAssured
                 .given()
@@ -403,16 +369,16 @@ public class NodeControllerIT extends AbstractIT {
      * Tests if nodes can be related by making a POST request to the node/bind endpoint and verifying the response.
      */
     @Test
-    @Order(12)
+    @Order(11)
     void theNodesAreRelated() {
         RestAssured
                 .given()
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
-                .body(String.format(payload("relate-node.json"), nodeUuid1, nodeUuid2, nodeUuid1,
+                .body(String.format(payload("relate-node.json"), graphUuid1, nodeUuid1, nodeUuid2, nodeUuid1,
                         nodeUuid3, nodeUuid2, nodeUuid3))
                 .when()
-                .post("/node/bind")
+                .post(NODE_ENDPOINT)
                 .then()
                 .extract()
                 .response();
@@ -423,7 +389,7 @@ public class NodeControllerIT extends AbstractIT {
      * graph endpoint and verifying the response.
      */
     @Test
-    @Order(13)
+    @Order(12)
     void weCanGetTheRelationOfNodesViaGraphUuid() {
         final Response response = RestAssured
                 .given()
@@ -443,7 +409,7 @@ public class NodeControllerIT extends AbstractIT {
      * Tests if a graph can be created and nodes can be bound to it and the relationships can be expanded.
      */
     @Test
-    @Order(14)
+    @Order(13)
     public void weCanCreateGraphAndNodesAndBindRelationshipsToExpand() {
         final Response response = RestAssured
                 .given()
@@ -473,7 +439,7 @@ public class NodeControllerIT extends AbstractIT {
      */
     @ParameterizedTest
     @CsvSource({"1, 4", "2, 9", "3, 11", "4, 14", "5, 15", "6, 16", "7, 16", "0, 1", "-1, 16", "1000, 16"})
-    @Order(15)
+    @Order(14)
     public void weCanGetThatExpandNodesNextByGraphUuidAndNodesName(final String degree, final String count) {
         final Response response = RestAssured
                 .given()
@@ -497,7 +463,7 @@ public class NodeControllerIT extends AbstractIT {
      * Tests if a node entity can be deleted by making a DELETE request to the node endpoint and verifying the response.
      */
     @Test
-    @Order(16)
+    @Order(15)
     void weCanDeleteThatNodeEntity() {
         final Response response = RestAssured
                 .given()
@@ -515,7 +481,7 @@ public class NodeControllerIT extends AbstractIT {
      * and verifying the response.
      */
     @Test
-    @Order(17)
+    @Order(16)
     void thatNodeEntityIsNotFoundInDatabaseAnymore() {
         final Response response = RestAssured
                 .given()

--- a/src/test/resources/payload/create-a-node.json
+++ b/src/test/resources/payload/create-a-node.json
@@ -1,6 +1,6 @@
 {
   "graphUuid": "%s",
-  "graphNodeDTO": [
+  "nodeDTO": [
     {
       "temporaryId": "1",
       "properties": {

--- a/src/test/resources/payload/create-graph-nodes-to-expand.json
+++ b/src/test/resources/payload/create-graph-nodes-to-expand.json
@@ -4,7 +4,7 @@
     "title": "-",
     "description": "-"
   },
-  "graphNodeDTO": [
+  "nodeDTO": [
     {
       "temporaryId": "1",
       "properties": {
@@ -102,7 +102,7 @@
       }
     }
   ],
-  "graphNodeRelationDTO": [
+  "nodeRelationDTO": [
     {
       "fromId": "1",
       "relationName": "-",

--- a/src/test/resources/payload/create-graph-nodes-to-valid.json
+++ b/src/test/resources/payload/create-graph-nodes-to-valid.json
@@ -4,7 +4,7 @@
     "title": "%s",
     "description": "%s"
   },
-  "graphNodeDTO": [
+  "nodeDTO": [
     {
       "temporaryId": "%s"
     },
@@ -12,7 +12,7 @@
       "temporaryId": "%s"
     }
   ],
-  "graphNodeRelationDTO": [
+  "nodeRelationDTO": [
     {
       "fromId": "%s",
       "relationName": "%s",

--- a/src/test/resources/payload/create-graph-nodes.json
+++ b/src/test/resources/payload/create-graph-nodes.json
@@ -4,7 +4,7 @@
     "title": "%s",
     "description": "-"
   },
-  "graphNodeDTO": [
+  "nodeDTO": [
     {
       "temporaryId": "1",
       "properties": {
@@ -48,7 +48,7 @@
       }
     }
   ],
-  "graphNodeRelationDTO": [
+  "nodeRelationDTO": [
     {
       "fromId": "1",
       "relationName": "-",

--- a/src/test/resources/payload/create-node.json
+++ b/src/test/resources/payload/create-node.json
@@ -1,6 +1,6 @@
 {
   "graphUuid": "%s",
-  "graphNodeDTO": [
+  "nodeDTO": [
     {
       "temporaryId": "1",
       "properties": {

--- a/src/test/resources/payload/create-nodes-to-valid.json
+++ b/src/test/resources/payload/create-nodes-to-valid.json
@@ -1,6 +1,6 @@
 {
   "graphUuid": "%s",
-  "graphNodeDTO": [
+  "nodeDTO": [
     {
       "temporaryId": "%s"
     },
@@ -8,7 +8,7 @@
       "temporaryId": "%s"
     }
   ],
-  "graphNodeRelationDTO": [
+  "nodeRelationDTO": [
     {
       "fromId": "%s",
       "relationName": "%s",

--- a/src/test/resources/payload/relate-node-to-valid.json
+++ b/src/test/resources/payload/relate-node-to-valid.json
@@ -1,7 +1,0 @@
-[
-  {
-    "fromId": "%s",
-    "relationName": "%s",
-    "toId": "%s"
-  }
-]

--- a/src/test/resources/payload/relate-node.json
+++ b/src/test/resources/payload/relate-node.json
@@ -1,17 +1,20 @@
-[
-  {
-    "fromId": "%s",
-    "relationName": "-",
-    "toId": "%s"
-  },
-  {
-    "fromId": "%s",
-    "relationName": "-",
-    "toId": "%s"
-  },
-  {
-    "fromId": "%s",
-    "relationName": "-",
-    "toId": "%s"
-  }
-]
+{
+  "graphUuid": "%s",
+  "nodeRelationDTO": [
+    {
+      "fromId": "%s",
+      "relationName": "-",
+      "toId": "%s"
+    },
+    {
+      "fromId": "%s",
+      "relationName": "-",
+      "toId": "%s"
+    },
+    {
+      "fromId": "%s",
+      "relationName": "-",
+      "toId": "%s"
+    }
+  ]
+}


### PR DESCRIPTION
[//]: # (Copyright 2024 Paion Data)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Changed
Modify the parameter handling conditions of the `createAndBindNode` interface.
Modify parameter names in some DTOs

### Removed
Remove the `bindNodes` interface and the corresponding tests.

