### PR TITLE
Add Spring Boot Web Dependency  

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,8 +254,14 @@
             <version>1.20.1</version>
             <scope>test</scope>
         </dependency>
-    </dependencies>
 
+        <!--Spring boot-->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-web</artifactId>
+                <version>3.3.6</version>
+            </dependency>
+    </dependencies>
     <build>
         <resources>
             <resource>


### PR DESCRIPTION
This pull request adds the **Spring Boot Starter Web** dependency to the `pom.xml` file, transforming the project into a Spring Boot web application.  

### Changes Made:  
1. Added the `spring-boot-starter-web` dependency in the `pom.xml`.  
   - This enables the project to function as a Spring Boot web application, supporting RESTful APIs and web controllers.  

## Why These Changes?  
- To set up the project as a web-based Spring Boot application.  
- This addition lays the foundation for developing web functionalities such as REST APIs, web controllers, and more.  

## Impact  
- Converts the project into a Spring Boot web application.  
- Introduces the necessary dependencies for Spring MVC components.  

## Testing  
- Verified the Maven build to ensure the dependency is successfully resolved.  
- Confirmed the application starts up as expected with the web dependency in place.  

## Checklist  
- [x] Added the web dependency to `pom.xml`.  
- [x] Verified the project builds successfully.  
- [x] Tested basic application startup with the new configuration.  

Please review and let me know if further changes are needed!  